### PR TITLE
Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,28 +76,39 @@ CHECK_LIBRARY_EXISTS(c vsyslog "stdarg.h" HAVE_VSYSLOG)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/cmake/json_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/json_config.h)
 
+# This function takes at least 2 arguments and prepends (path) to each entry from 2-N
+# It can be used to convert a list of relative file paths into absolute ones
+FUNCTION(PREPEND var prefix)
+   SET(listVar "")
+   FOREACH(f ${ARGN})
+      LIST(APPEND listVar "${prefix}/${f}")
+   ENDFOREACH(f)
+   SET(${var} "${listVar}" PARENT_SCOPE)
+ENDFUNCTION(PREPEND)
 
 
 set(JSON_C_HEADERS
-    ./json.h
-    ./json_c_version.h
+    json.h
+    json_c_version.h
+    arraylist.h
+    debug.h
+    json_inttypes.h
+    json_object.h
+    json_object_private.h
+    json_object_iterator.h
+    json_pointer.h
+    json_tokener.h
+    json_util.h
+    linkhash.h
+    math_compat.h
+    strdup_compat.h
+    vasprintf_compat.h
+    printbuf.h
+    random_seed.h
+)
+set(JSON_C_GENERATED_HEADERS
     ${CMAKE_CURRENT_BINARY_DIR}/include/json_config.h
     ${CMAKE_CURRENT_BINARY_DIR}/include/config.h
-    ./arraylist.h
-    ./debug.h
-    ./json_inttypes.h
-    ./json_object.h
-    ./json_object_private.h
-    ./json_object_iterator.h
-    ./json_pointer.h
-    ./json_tokener.h
-    ./json_util.h
-    ./linkhash.h
-    ./math_compat.h
-    ./strdup_compat.h
-    ./vasprintf_compat.h
-    ./printbuf.h
-    ./random_seed.h
 )
 
 set(JSON_C_SOURCES
@@ -112,9 +123,14 @@ set(JSON_C_SOURCES
     ./random_seed.c
 )
 
+# we will need absolute paths to each header for some commands
+PREPEND(JSON_C_HEADERS_ABSPATH ${CMAKE_CURRENT_SOURCE_DIR} ${JSON_C_HEADERS})
+
+
 add_library(json-c-objlib OBJECT
   ${JSON_C_SOURCES}
   ${JSON_C_HEADERS}
+  ${JSON_C_GENERATED_HEADERS}
 )
 
 # shared libraries need PIC
@@ -135,6 +151,13 @@ set(MYLIB_VERSION_STRING ${MYLIB_VERSION_MAJOR}.${MYLIB_VERSION_MINOR}.${MYLIB_V
 set_target_properties(json-c-shared PROPERTIES VERSION ${MYLIB_VERSION_STRING}
                                            SOVERSION ${MYLIB_VERSION_MAJOR})
 
+
+# copy required json assets to output directory
+add_custom_command(TARGET json-c-shared POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${JSON_C_HEADERS_ABSPATH} ${CMAKE_CURRENT_BINARY_DIR}/include
+        )
+
 # installation locations
 install(TARGETS json-c-static json-c-shared
     RUNTIME DESTINATION bin
@@ -144,4 +167,5 @@ install(TARGETS json-c-static json-c-shared
 
 #install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/json-c FILES_MATCHING PATTERN "*.h")
 #install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/json-c FILES_MATCHING PATTERN "*.h")
-install(FILES ${JSON_C_HEADERS} DESTINATION include/json-c )
+install(FILES ${JSON_C_HEADERS} ${JSON_C_GENERATED_HEADERS} DESTINATION include/json-c )
+

--- a/build.xml
+++ b/build.xml
@@ -3,6 +3,7 @@
     <description>Json-C build wrapper around cmake</description>
 
     <property name="config" value="Debug" />
+    <property name="cmake" value="cmake" />
 
    
     <condition property="isWindows">
@@ -36,7 +37,7 @@
 
 
      <target name="cmake" depends="prepare">
-         <exec executable="cmake" dir="build" failonerror="true">
+         <exec executable="${cmake}" dir="build" failonerror="true">
                <arg value="-G" />
                <arg value="${cmake-generator}" />
                <arg value="-DCMAKE_BUILD_TYPE=${config}" />

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,19 @@
 
 <project name="json-c" default="jarall" basedir=".">
     <description>Json-C build wrapper around cmake</description>
-    
+
+    <property name="config" value="Debug" />
+
+   
+    <condition property="isWindows">
+                    <os family="windows" />
+    </condition>
+    <condition property="isUnix">
+                    <os family="unix" />
+    </condition>
+
+
+ 
     <target name="clean">
         <echo message="Cleaning files" />
          <delete includeEmptyDirs="true" failonerror="false">
@@ -9,17 +21,39 @@
          </delete>
      </target>
 
-     <target name="cmake">
+
+     <target name="prepare" depends="prepare.if.unix, prepare.if.windows">
         <mkdir dir="build" />
-         <exec executable="${tools.basedir}/3rdparty/cmake/bin/cmake" dir="build" failonerror="true">
+     </target>
+     <target name="prepare.if.unix" if="isUnix">
+        <property name="cmake-generator" value="Unix Makefiles" />
+     </target>
+     <target name="prepare.if.windows" if="isWindows">
+        <property name="cmake-generator" value="Visual Studio 12 2013 Win64" />
+     </target>
+
+
+     <target name="cmake">
+         <exec executable="cmake" dir="build" failonerror="true">
+               <arg value="-G" />
+               <arg value="Visual Studio 12 2013 Win64" />
+               <arg value="-DCMAKE_BUILD_TYPE=${config}" />
                <arg value=".." />
         </exec>
     </target>
 
-    <target name="compile" depends="cmake" >
-        <exec executable="make" dir="build" failonerror="true">
-        </exec>        
+
+    <target name="compile" depends="compile.if.unix, compile.if.windows" />
+    <target name="compile.if.unix" depends="cmake" if="isUnix" >
+        <exec executable="make" dir="build" failonerror="true" />
     </target>
+    <target name="compile.if.windows" depends="cmake" if="isWindows" >
+        <exec executable="msbuild" dir="build" failonerror="true">
+               <arg value="json-c.sln" />
+               <arg value="/p:Configuration=${config}" />
+        </exec>
+    </target>
+
 
     <target name="jarall" depends="clean,compile">
         <echo message="*** will commit output library files to DevTools/IneoQuest after testing ***" />

--- a/build.xml
+++ b/build.xml
@@ -27,16 +27,18 @@
      </target>
      <target name="prepare.if.unix" if="isUnix">
         <property name="cmake-generator" value="Unix Makefiles" />
+        <echo message="preparing for unix builds using Makefiles" />
      </target>
      <target name="prepare.if.windows" if="isWindows">
         <property name="cmake-generator" value="Visual Studio 12 2013 Win64" />
+        <echo message="preparing for Windows builds using Visual Studio (msbuild), make sure you are using the Visual Studio 2013 Command Shell to build." />
      </target>
 
 
-     <target name="cmake">
+     <target name="cmake" depends="prepare">
          <exec executable="cmake" dir="build" failonerror="true">
                <arg value="-G" />
-               <arg value="Visual Studio 12 2013 Win64" />
+               <arg value="${cmake-generator}" />
                <arg value="-DCMAKE_BUILD_TYPE=${config}" />
                <arg value=".." />
         </exec>

--- a/linkhash.c
+++ b/linkhash.c
@@ -450,7 +450,6 @@ static unsigned long lh_perllike_str_hash(const void *k)
     return hashval;
 }
 
-#if defined(__linux__)
 
 #ifdef __cplusplus
 #define INITIALIZER(f) \
@@ -494,7 +493,6 @@ INITIALIZER(init_hash_random_seed) {
 	}
 }
 
-#endif // defined __linux__
 
 
 static unsigned long lh_char_hash(const void *k)


### PR DESCRIPTION
Now copies all headers into build/include dir so externals can -I into that directory for builds instead of having to install.

Fixed windows build issue where windows essential defines were surrounded by a #if LINUX guard.